### PR TITLE
Implemented delete for Sending Domains API

### DIFF
--- a/examples/java/io/mailtrap/examples/sendingdomains/SendingDomains.java
+++ b/examples/java/io/mailtrap/examples/sendingdomains/SendingDomains.java
@@ -1,0 +1,40 @@
+package io.mailtrap.examples.sendingdomains;
+
+import io.mailtrap.config.MailtrapConfig;
+import io.mailtrap.factory.MailtrapClientFactory;
+import io.mailtrap.model.request.sendingdomains.CreateSendingDomainRequest;
+import io.mailtrap.model.request.sendingdomains.SendingDomainsSetupInstructionsRequest;
+
+import static io.mailtrap.model.request.sendingdomains.CreateSendingDomainRequest.SendingDomainData;
+
+public class SendingDomains {
+
+    private static final String TOKEN = "<YOUR MAILTRAP TOKEN>";
+    private static final long ACCOUNT_ID = 1L;
+    private static final String DOMAIN_NAME = "test.io";
+    private static final String DEVOPS_EMAIL = "devops@test.io";
+
+    public static void main(String[] args) {
+        final var config = new MailtrapConfig.Builder()
+            .token(TOKEN)
+            .build();
+
+        final var client = MailtrapClientFactory.createMailtrapClient(config);
+
+        final var createRequest = new CreateSendingDomainRequest(new SendingDomainData(DOMAIN_NAME));
+
+        final var createdDomain = client.sendingApi().domains().create(ACCOUNT_ID, createRequest);
+        System.out.println(createdDomain);
+
+        final var domainById = client.sendingApi().domains().getSendingDomain(ACCOUNT_ID, createdDomain.getId());
+        System.out.println(domainById);
+
+        final var allDomains = client.sendingApi().domains().getSendingDomains(ACCOUNT_ID);
+        System.out.println(allDomains);
+
+        final var sendInstructionsRequest = new SendingDomainsSetupInstructionsRequest(DEVOPS_EMAIL);
+        client.sendingApi().domains().sendSendingDomainsSetupInstructions(ACCOUNT_ID, createdDomain.getId(), sendInstructionsRequest);
+
+        client.sendingApi().domains().deleteSendingDomain(ACCOUNT_ID, createdDomain.getId());
+    }
+}

--- a/src/main/java/io/mailtrap/api/sendingdomains/SendingDomains.java
+++ b/src/main/java/io/mailtrap/api/sendingdomains/SendingDomains.java
@@ -42,4 +42,12 @@ public interface SendingDomains {
      * @param request         request data
      */
     void sendSendingDomainsSetupInstructions(long accountId, long sendingDomainId, SendingDomainsSetupInstructionsRequest request);
+
+    /**
+     * Delete a sending domain
+     *
+     * @param accountId       unique account ID
+     * @param sendingDomainId unique domain ID
+     */
+    void deleteSendingDomain(long accountId, long sendingDomainId);
 }

--- a/src/main/java/io/mailtrap/api/sendingdomains/SendingDomainsImpl.java
+++ b/src/main/java/io/mailtrap/api/sendingdomains/SendingDomainsImpl.java
@@ -54,4 +54,14 @@ public class SendingDomainsImpl extends ApiResource implements SendingDomains {
                 Void.class
         );
     }
+
+    @Override
+    public void deleteSendingDomain(long accountId, long sendingDomainId) {
+        httpClient
+            .delete(
+                String.format(apiHost + "/api/accounts/%d/sending_domains/%d", accountId, sendingDomainId),
+                new RequestData(),
+                Void.class
+            );
+    }
 }

--- a/src/test/java/io/mailtrap/api/sendingdomains/SendingDomainsImplTest.java
+++ b/src/test/java/io/mailtrap/api/sendingdomains/SendingDomainsImplTest.java
@@ -23,28 +23,32 @@ class SendingDomainsImplTest extends BaseTest {
     @BeforeEach
     public void init() {
         TestHttpClient httpClient = new TestHttpClient(List.of(
-                DataMock.build(
-                        Constants.GENERAL_HOST + "/api/accounts/" + accountId + "/sending_domains",
-                        "POST", "api/sending_domains/createSendingDomainRequest.json", "api/sending_domains/sendingDomainResponse.json"
-                ),
-                DataMock.build(
-                        Constants.GENERAL_HOST + "/api/accounts/" + accountId + "/sending_domains",
-                        "GET", null, "api/sending_domains/sendingDomainsResponse.json"
-                ),
-                DataMock.build(
-                        Constants.GENERAL_HOST + "/api/accounts/" + accountId + "/sending_domains/" + sendingDomainId,
-                        "GET", null, "api/sending_domains/sendingDomainResponse.json"
-                ),
-                DataMock.build(
-                        Constants.GENERAL_HOST + "/api/accounts/" + accountId + "/sending_domains/" + sendingDomainId + "/send_setup_instructions",
-                        "POST", "api/sending_domains/sendSetupInstructionsRequest.json", null
-                )
+            DataMock.build(
+                Constants.GENERAL_HOST + "/api/accounts/" + accountId + "/sending_domains",
+                "POST", "api/sending_domains/createSendingDomainRequest.json", "api/sending_domains/sendingDomainResponse.json"
+            ),
+            DataMock.build(
+                Constants.GENERAL_HOST + "/api/accounts/" + accountId + "/sending_domains",
+                "GET", null, "api/sending_domains/sendingDomainsResponse.json"
+            ),
+            DataMock.build(
+                Constants.GENERAL_HOST + "/api/accounts/" + accountId + "/sending_domains/" + sendingDomainId,
+                "GET", null, "api/sending_domains/sendingDomainResponse.json"
+            ),
+            DataMock.build(
+                Constants.GENERAL_HOST + "/api/accounts/" + accountId + "/sending_domains/" + sendingDomainId + "/send_setup_instructions",
+                "POST", "api/sending_domains/sendSetupInstructionsRequest.json", null
+            ),
+            DataMock.build(
+                Constants.GENERAL_HOST + "/api/accounts/" + accountId + "/sending_domains/" + sendingDomainId,
+                "DELETE", null, null
+            )
         ));
 
         MailtrapConfig testConfig = new MailtrapConfig.Builder()
-                .httpClient(httpClient)
-                .token("dummy_token")
-                .build();
+            .httpClient(httpClient)
+            .token("dummy_token")
+            .build();
 
         domains = MailtrapClientFactory.createMailtrapClient(testConfig).sendingApi().domains();
     }
@@ -81,5 +85,10 @@ class SendingDomainsImplTest extends BaseTest {
     @Test
     void test_sendSendingDomainsSetupInstructions() {
         domains.sendSendingDomainsSetupInstructions(accountId, sendingDomainId, new SendingDomainsSetupInstructionsRequest("devops@test.io"));
+    }
+
+    @Test
+    void test_deleteSendingDomain() {
+        assertDoesNotThrow(() -> domains.deleteSendingDomain(accountId, sendingDomainId));
     }
 }


### PR DESCRIPTION
## Motivation
Implement the DELETE method for the Sending Domains API to keep the SDK up-to-date


## Changes

-  Added DELETE method, unit test
- Added example class

