### PR TITLE
Implement `/batch` method for sending/testing/bulk emails

### DIFF
--- a/examples/java/io/mailtrap/examples/bulk/Batch.java
+++ b/examples/java/io/mailtrap/examples/bulk/Batch.java
@@ -1,0 +1,43 @@
+package io.mailtrap.examples.bulk;
+
+import io.mailtrap.config.MailtrapConfig;
+import io.mailtrap.factory.MailtrapClientFactory;
+import io.mailtrap.model.request.emails.Address;
+import io.mailtrap.model.request.emails.MailtrapBatchMail;
+import io.mailtrap.model.request.emails.BatchEmailBase;
+import io.mailtrap.model.request.emails.MailtrapMail;
+
+import java.util.List;
+import java.util.Map;
+
+public class Bulk {
+
+    private static final String TOKEN = "<YOUR MAILTRAP TOKEN>";
+    private static final String SENDER_EMAIL = "sender@domain.com";
+    private static final String RECIPIENT_EMAIL = "recipient@domain.com";
+
+    public static void main(String[] args) {
+        final var config = new MailtrapConfig.Builder()
+            .token(TOKEN)
+            .build();
+
+        final var client = MailtrapClientFactory.createMailtrapClient(config);
+
+        final var mail = MailtrapMail.builder()
+            .from(new Address(SENDER_EMAIL))
+            .to(List.of(new Address(RECIPIENT_EMAIL)))
+            .subject("Hello from Mailtrap!")
+            .text("Welcome to Mailtrap Bulk Sending!")
+            .build();
+
+        final var batchMail = MailtrapBatchMail.builder()
+            // Optionally you can add this `base` object - if you have some common data across emails
+            // Each property can be overridden in `requests` for individual emails
+            .base(BatchEmailBase.builder().subject("Base Subject for all emails").build())
+            .requests(List.of(mail))
+            .build();
+
+        System.out.println(client.bulkSendingApi().emails().batchSend(batchMail));
+    }
+
+}

--- a/examples/java/io/mailtrap/examples/bulk/Batch.java
+++ b/examples/java/io/mailtrap/examples/bulk/Batch.java
@@ -10,7 +10,7 @@ import io.mailtrap.model.request.emails.MailtrapMail;
 import java.util.List;
 import java.util.Map;
 
-public class Bulk {
+public class Batch {
 
     private static final String TOKEN = "<YOUR MAILTRAP TOKEN>";
     private static final String SENDER_EMAIL = "sender@domain.com";

--- a/examples/java/io/mailtrap/examples/sending/Batch.java
+++ b/examples/java/io/mailtrap/examples/sending/Batch.java
@@ -1,0 +1,43 @@
+package io.mailtrap.examples.sending;
+
+import io.mailtrap.config.MailtrapConfig;
+import io.mailtrap.factory.MailtrapClientFactory;
+import io.mailtrap.model.request.emails.Address;
+import io.mailtrap.model.request.emails.MailtrapBatchMail;
+import io.mailtrap.model.request.emails.BatchEmailBase;
+import io.mailtrap.model.request.emails.MailtrapMail;
+
+import java.util.List;
+import java.util.Map;
+
+public class Bulk {
+
+    private static final String TOKEN = "<YOUR MAILTRAP TOKEN>";
+    private static final String SENDER_EMAIL = "sender@domain.com";
+    private static final String RECIPIENT_EMAIL = "recipient@domain.com";
+
+    public static void main(String[] args) {
+        final var config = new MailtrapConfig.Builder()
+            .token(TOKEN)
+            .build();
+
+        final var client = MailtrapClientFactory.createMailtrapClient(config);
+
+        final var mail = MailtrapMail.builder()
+            .from(new Address(SENDER_EMAIL))
+            .to(List.of(new Address(RECIPIENT_EMAIL)))
+            .subject("Hello from Mailtrap Sending!")
+            .text("Welcome to Mailtrap Sending!")
+            .build();
+
+        final var batchMail = MailtrapBatchMail.builder()
+            // Optionally you can add this `base` object - if you have some common data across emails
+            // Each property can be overridden in `requests` for individual emails
+            .base(BatchEmailBase.builder().subject("Base Subject for all emails").build())
+            .requests(List.of(mail))
+            .build();
+
+        System.out.println(client.sendingApi().emails().batchSend(batchMail));
+    }
+
+}

--- a/examples/java/io/mailtrap/examples/sending/Batch.java
+++ b/examples/java/io/mailtrap/examples/sending/Batch.java
@@ -10,7 +10,7 @@ import io.mailtrap.model.request.emails.MailtrapMail;
 import java.util.List;
 import java.util.Map;
 
-public class Bulk {
+public class Batch {
 
     private static final String TOKEN = "<YOUR MAILTRAP TOKEN>";
     private static final String SENDER_EMAIL = "sender@domain.com";

--- a/examples/java/io/mailtrap/examples/testing/Batch.java
+++ b/examples/java/io/mailtrap/examples/testing/Batch.java
@@ -1,0 +1,48 @@
+package io.mailtrap.examples.testing;
+
+import io.mailtrap.config.MailtrapConfig;
+import io.mailtrap.factory.MailtrapClientFactory;
+import io.mailtrap.model.request.emails.Address;
+import io.mailtrap.model.request.emails.MailtrapBatchMail;
+import io.mailtrap.model.request.emails.BatchEmailBase;
+import io.mailtrap.model.request.emails.MailtrapMail;
+
+import java.util.List;
+import java.util.Map;
+
+public class Batch {
+
+    private static final String TOKEN = "<YOUR MAILTRAP TOKEN>";
+    private static final String SENDER_EMAIL = "sender@domain.com";
+    private static final String RECIPIENT_EMAIL = "recipient@domain.com";
+    private static final long INBOX_ID = 1337L;
+
+    public static void main(String[] args) {
+        final var config = new MailtrapConfig.Builder()
+            .token(TOKEN)
+            .inboxId(INBOX_ID)
+            .build();
+
+        final var client = MailtrapClientFactory.createMailtrapClient(config);
+
+        final var mail = MailtrapMail.builder()
+            .from(new Address("John Doe", SENDER_EMAIL))
+            .to(List.of(new Address("Jane Doe", RECIPIENT_EMAIL)))
+            .templateUuid("813t39es-t74i-4308-b037-0n6bg8b1fe88")
+            .templateVariables(Map.of(
+                "user_name", "Jack Sparrow",
+                "testing_template", "true"
+            ))
+            .build();
+
+        final var batchMail = MailtrapBatchMail.builder()
+            // Optionally you can add this `base` object - if you have some common data across emails
+            // Each property can be overridden in `requests` for individual emails
+            .base(BatchEmailBase.builder().subject("Base Subject for all emails").build())
+            .requests(List.of(mail))
+            .build();
+
+        System.out.println(client.testingApi().emails().batchSend(batchMail, config.getInboxId()));
+    }
+
+}

--- a/examples/java/io/mailtrap/examples/testing/Batch.java
+++ b/examples/java/io/mailtrap/examples/testing/Batch.java
@@ -38,7 +38,7 @@ public class Batch {
         final var batchMail = MailtrapBatchMail.builder()
             // Optionally you can add this `base` object - if you have some common data across emails
             // Each property can be overridden in `requests` for individual emails
-            .base(BatchEmailBase.builder().subject("Base Subject for all emails").build())
+            .base(BatchEmailBase.builder().templateUuid("base-template-uuid").build())
             .requests(List.of(mail))
             .build();
 

--- a/src/main/java/io/mailtrap/api/apiresource/SendApiResource.java
+++ b/src/main/java/io/mailtrap/api/apiresource/SendApiResource.java
@@ -3,6 +3,7 @@ package io.mailtrap.api.apiresource;
 import io.mailtrap.CustomValidator;
 import io.mailtrap.config.MailtrapConfig;
 import io.mailtrap.exception.InvalidRequestBodyException;
+import io.mailtrap.model.request.emails.MailtrapBatchMail;
 import io.mailtrap.model.request.emails.MailtrapMail;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -16,13 +17,19 @@ public abstract class SendApiResource extends ApiResourceWithValidation {
         super(config, customValidator);
     }
 
+    protected void assertBatchMailNotNull(MailtrapBatchMail batchMail){
+        if (batchMail == null) {
+            throw new InvalidRequestBodyException("BatchMail must not be null");
+        }
+    }
+
     /**
      * Validates the request body of an email message and throws an exception if it is invalid.
      *
      * @param mail The email message to be validated.
      * @throws InvalidRequestBodyException If the request body is invalid.
      */
-    protected void validateRequestBodyOrThrowException(MailtrapMail mail) throws InvalidRequestBodyException {
+    protected void validateMailPayload(MailtrapMail mail) throws InvalidRequestBodyException {
         // Check if the mail object itself is null
         if (mail == null) {
             throw new InvalidRequestBodyException("Mail must not be null");
@@ -30,8 +37,8 @@ public abstract class SendApiResource extends ApiResourceWithValidation {
 
         // Check if all three subject, text, and html are empty
         boolean isSubjectTextHtmlEmpty = StringUtils.isEmpty(mail.getSubject())
-                && StringUtils.isEmpty(mail.getText())
-                && StringUtils.isEmpty(mail.getHtml());
+            && StringUtils.isEmpty(mail.getText())
+            && StringUtils.isEmpty(mail.getHtml());
 
         // Validate depending on whether the templateUuid is set
         if (StringUtils.isEmpty(mail.getTemplateUuid())) {

--- a/src/main/java/io/mailtrap/api/bulkemails/BulkEmails.java
+++ b/src/main/java/io/mailtrap/api/bulkemails/BulkEmails.java
@@ -2,7 +2,9 @@ package io.mailtrap.api.bulkemails;
 
 import io.mailtrap.exception.InvalidRequestBodyException;
 import io.mailtrap.exception.http.HttpException;
+import io.mailtrap.model.request.emails.MailtrapBatchMail;
 import io.mailtrap.model.request.emails.MailtrapMail;
+import io.mailtrap.model.response.emails.BatchSendResponse;
 import io.mailtrap.model.response.emails.SendResponse;
 
 /**
@@ -20,4 +22,6 @@ public interface BulkEmails {
      * @throws InvalidRequestBodyException If the request body is invalid.
      */
     SendResponse send(MailtrapMail mail) throws HttpException, InvalidRequestBodyException;
+
+    BatchSendResponse batchSend(MailtrapBatchMail mail) throws HttpException, InvalidRequestBodyException;
 }

--- a/src/main/java/io/mailtrap/api/bulkemails/BulkEmailsImpl.java
+++ b/src/main/java/io/mailtrap/api/bulkemails/BulkEmailsImpl.java
@@ -4,8 +4,12 @@ import io.mailtrap.Constants;
 import io.mailtrap.CustomValidator;
 import io.mailtrap.api.apiresource.SendApiResource;
 import io.mailtrap.config.MailtrapConfig;
+import io.mailtrap.exception.InvalidRequestBodyException;
+import io.mailtrap.exception.http.HttpException;
 import io.mailtrap.http.RequestData;
+import io.mailtrap.model.request.emails.MailtrapBatchMail;
 import io.mailtrap.model.request.emails.MailtrapMail;
+import io.mailtrap.model.response.emails.BatchSendResponse;
 import io.mailtrap.model.response.emails.SendResponse;
 
 /**
@@ -20,11 +24,24 @@ public class BulkEmailsImpl extends SendApiResource implements BulkEmails {
 
     @Override
     public SendResponse send(MailtrapMail mail) {
-        validateRequestBodyOrThrowException(mail);
+        validateMailPayload(mail);
         RequestData requestData = new RequestData();
         if (mail.getHeaders() != null) {
             requestData.setHeaders(mail.getHeaders());
         }
         return httpClient.post(apiHost + "/api/send", mail, requestData, SendResponse.class);
+    }
+
+    @Override
+    public BatchSendResponse batchSend(MailtrapBatchMail mail) throws HttpException, InvalidRequestBodyException {
+        assertBatchMailNotNull(mail);
+
+        mail
+            .getRequests()
+            .forEach(this::validateMailPayload);
+
+        return
+            httpClient.post(apiHost + "/api/batch", mail, new RequestData(), BatchSendResponse.class);
+
     }
 }

--- a/src/main/java/io/mailtrap/api/bulkemails/BulkEmailsImpl.java
+++ b/src/main/java/io/mailtrap/api/bulkemails/BulkEmailsImpl.java
@@ -34,11 +34,7 @@ public class BulkEmailsImpl extends SendApiResource implements BulkEmails {
 
     @Override
     public BatchSendResponse batchSend(MailtrapBatchMail mail) throws HttpException, InvalidRequestBodyException {
-        assertBatchMailNotNull(mail);
-
-        mail
-            .getRequests()
-            .forEach(this::validateMailPayload);
+        validateBatchPayload(mail);
 
         return
             httpClient.post(apiHost + "/api/batch", mail, new RequestData(), BatchSendResponse.class);

--- a/src/main/java/io/mailtrap/api/sendingemails/SendingEmails.java
+++ b/src/main/java/io/mailtrap/api/sendingemails/SendingEmails.java
@@ -2,7 +2,9 @@ package io.mailtrap.api.sendingemails;
 
 import io.mailtrap.exception.InvalidRequestBodyException;
 import io.mailtrap.exception.http.HttpException;
+import io.mailtrap.model.request.emails.MailtrapBatchMail;
 import io.mailtrap.model.request.emails.MailtrapMail;
+import io.mailtrap.model.response.emails.BatchSendResponse;
 import io.mailtrap.model.response.emails.SendResponse;
 
 /**
@@ -20,4 +22,6 @@ public interface SendingEmails {
      * @throws InvalidRequestBodyException If the request body is invalid.
      */
     SendResponse send(MailtrapMail mail) throws HttpException, InvalidRequestBodyException;
+
+    BatchSendResponse batchSend(MailtrapBatchMail mail) throws HttpException, InvalidRequestBodyException;
 }

--- a/src/main/java/io/mailtrap/api/sendingemails/SendingEmailsImpl.java
+++ b/src/main/java/io/mailtrap/api/sendingemails/SendingEmailsImpl.java
@@ -4,8 +4,12 @@ import io.mailtrap.Constants;
 import io.mailtrap.CustomValidator;
 import io.mailtrap.api.apiresource.SendApiResource;
 import io.mailtrap.config.MailtrapConfig;
+import io.mailtrap.exception.InvalidRequestBodyException;
+import io.mailtrap.exception.http.HttpException;
 import io.mailtrap.http.RequestData;
+import io.mailtrap.model.request.emails.MailtrapBatchMail;
 import io.mailtrap.model.request.emails.MailtrapMail;
+import io.mailtrap.model.response.emails.BatchSendResponse;
 import io.mailtrap.model.response.emails.SendResponse;
 
 /**
@@ -20,12 +24,24 @@ public class SendingEmailsImpl extends SendApiResource implements SendingEmails 
 
     @Override
     public SendResponse send(MailtrapMail mail) {
-        validateRequestBodyOrThrowException(mail);
+        validateMailPayload(mail);
         RequestData requestData = new RequestData();
         if (mail.getHeaders() != null) {
             requestData.setHeaders(mail.getHeaders());
         }
         return httpClient.post(apiHost + "/api/send", mail, requestData, SendResponse.class);
+    }
+
+    @Override
+    public BatchSendResponse batchSend(MailtrapBatchMail mail) throws HttpException, InvalidRequestBodyException {
+        assertBatchMailNotNull(mail);
+
+        mail
+            .getRequests()
+            .forEach(this::validateMailPayload);
+
+        return
+            httpClient.post(apiHost + "/api/batch", mail, new RequestData(), BatchSendResponse.class);
     }
 
 }

--- a/src/main/java/io/mailtrap/api/sendingemails/SendingEmailsImpl.java
+++ b/src/main/java/io/mailtrap/api/sendingemails/SendingEmailsImpl.java
@@ -34,11 +34,7 @@ public class SendingEmailsImpl extends SendApiResource implements SendingEmails 
 
     @Override
     public BatchSendResponse batchSend(MailtrapBatchMail mail) throws HttpException, InvalidRequestBodyException {
-        assertBatchMailNotNull(mail);
-
-        mail
-            .getRequests()
-            .forEach(this::validateMailPayload);
+        validateBatchPayload(mail);
 
         return
             httpClient.post(apiHost + "/api/batch", mail, new RequestData(), BatchSendResponse.class);

--- a/src/main/java/io/mailtrap/api/testingemails/TestingEmails.java
+++ b/src/main/java/io/mailtrap/api/testingemails/TestingEmails.java
@@ -2,7 +2,9 @@ package io.mailtrap.api.testingemails;
 
 import io.mailtrap.exception.InvalidRequestBodyException;
 import io.mailtrap.exception.http.HttpException;
+import io.mailtrap.model.request.emails.MailtrapBatchMail;
 import io.mailtrap.model.request.emails.MailtrapMail;
+import io.mailtrap.model.response.emails.BatchSendResponse;
 import io.mailtrap.model.response.emails.SendResponse;
 
 /**
@@ -21,4 +23,6 @@ public interface TestingEmails {
      * @throws InvalidRequestBodyException If the request body is invalid.
      */
     SendResponse send(MailtrapMail mail, long inboxId) throws HttpException, InvalidRequestBodyException;
+
+    BatchSendResponse batchSend(MailtrapBatchMail mail, long inboxId) throws HttpException, InvalidRequestBodyException;
 }

--- a/src/main/java/io/mailtrap/api/testingemails/TestingEmailsImpl.java
+++ b/src/main/java/io/mailtrap/api/testingemails/TestingEmailsImpl.java
@@ -4,8 +4,12 @@ import io.mailtrap.Constants;
 import io.mailtrap.CustomValidator;
 import io.mailtrap.api.apiresource.SendApiResource;
 import io.mailtrap.config.MailtrapConfig;
+import io.mailtrap.exception.InvalidRequestBodyException;
+import io.mailtrap.exception.http.HttpException;
 import io.mailtrap.http.RequestData;
+import io.mailtrap.model.request.emails.MailtrapBatchMail;
 import io.mailtrap.model.request.emails.MailtrapMail;
+import io.mailtrap.model.response.emails.BatchSendResponse;
 import io.mailtrap.model.response.emails.SendResponse;
 
 /**
@@ -20,11 +24,24 @@ public class TestingEmailsImpl extends SendApiResource implements TestingEmails 
 
     @Override
     public SendResponse send(MailtrapMail mail, long inboxId) {
-        validateRequestBodyOrThrowException(mail);
+        validateMailPayload(mail);
         RequestData requestData = new RequestData();
         if (mail.getHeaders() != null) {
             requestData.setHeaders(mail.getHeaders());
         }
         return httpClient.post(String.format(apiHost + "/api/send/%d", inboxId), mail, requestData, SendResponse.class);
+    }
+
+    @Override
+    public BatchSendResponse batchSend(MailtrapBatchMail mail, long inboxId) throws HttpException, InvalidRequestBodyException {
+        assertBatchMailNotNull(mail);
+
+        mail
+            .getRequests()
+            .forEach(this::validateMailPayload);
+
+        return
+            httpClient.post(String.format(apiHost + "/api/batch/%d", inboxId), mail, new RequestData(), BatchSendResponse.class);
+
     }
 }

--- a/src/main/java/io/mailtrap/api/testingemails/TestingEmailsImpl.java
+++ b/src/main/java/io/mailtrap/api/testingemails/TestingEmailsImpl.java
@@ -34,11 +34,7 @@ public class TestingEmailsImpl extends SendApiResource implements TestingEmails 
 
     @Override
     public BatchSendResponse batchSend(MailtrapBatchMail mail, long inboxId) throws HttpException, InvalidRequestBodyException {
-        assertBatchMailNotNull(mail);
-
-        mail
-            .getRequests()
-            .forEach(this::validateMailPayload);
+        validateBatchPayload(mail);
 
         return
             httpClient.post(String.format(apiHost + "/api/batch/%d", inboxId), mail, new RequestData(), BatchSendResponse.class);

--- a/src/main/java/io/mailtrap/client/MailtrapClient.java
+++ b/src/main/java/io/mailtrap/client/MailtrapClient.java
@@ -2,7 +2,9 @@ package io.mailtrap.client;
 
 import io.mailtrap.client.api.*;
 import io.mailtrap.config.MailtrapConfig;
+import io.mailtrap.model.request.emails.MailtrapBatchMail;
 import io.mailtrap.model.request.emails.MailtrapMail;
+import io.mailtrap.model.response.emails.BatchSendResponse;
 import io.mailtrap.model.response.emails.SendResponse;
 import io.mailtrap.util.SendingContextHolder;
 import lombok.Getter;
@@ -73,6 +75,22 @@ public class MailtrapClient {
             return testingApi.emails().send(mailtrapMail, sendingContextHolder.getInboxId());
         } else {
             return sendingApi.emails().send(mailtrapMail);
+        }
+    }
+
+    /**
+     * Sends an email based on the specified sending configuration.
+     *
+     * @param mailtrapBatchMail emails to send
+     * @return the response from the sending operation
+     */
+    public BatchSendResponse batchSend(MailtrapBatchMail mailtrapBatchMail) {
+        if (sendingContextHolder.isBulk()) {
+            return bulkSendingApi.emails().batchSend(mailtrapBatchMail);
+        } else if (sendingContextHolder.isSandbox()) {
+            return testingApi.emails().batchSend(mailtrapBatchMail, sendingContextHolder.getInboxId());
+        } else {
+            return sendingApi.emails().batchSend(mailtrapBatchMail);
         }
     }
 

--- a/src/main/java/io/mailtrap/exception/InvalidRequestBodyException.java
+++ b/src/main/java/io/mailtrap/exception/InvalidRequestBodyException.java
@@ -9,4 +9,8 @@ public class InvalidRequestBodyException extends BaseMailtrapException {
         super(errorMessage);
     }
 
+    public InvalidRequestBodyException(String errorMessage, Exception cause) {
+        super(errorMessage, cause);
+    }
+
 }

--- a/src/main/java/io/mailtrap/model/mailvalidation/ContentView.java
+++ b/src/main/java/io/mailtrap/model/mailvalidation/ContentView.java
@@ -1,0 +1,21 @@
+package io.mailtrap.model.mailvalidation;
+
+import java.util.Map;
+
+/**
+ * An adapter used by mail content validation rules. It exposes only the fields that participate in
+ * subject/text/html/template logic so the same rules can run for both single and batch sends.
+ */
+public interface ContentView {
+
+    String getSubject();
+
+    String getText();
+
+    String getHtml();
+
+    String getTemplateUuid();
+
+    Map<String, Object> getTemplateVariables();
+
+}

--- a/src/main/java/io/mailtrap/model/mailvalidation/MailContentView.java
+++ b/src/main/java/io/mailtrap/model/mailvalidation/MailContentView.java
@@ -1,0 +1,41 @@
+package io.mailtrap.model.mailvalidation;
+
+import io.mailtrap.model.request.emails.MailtrapMail;
+
+import java.util.Map;
+
+/**
+ * ContentView implementation for a single-send MailtrapMail.
+ */
+public final class MailContentView implements ContentView {
+    private final MailtrapMail mail;
+
+    public String getSubject() {
+        return mail.getSubject();
+    }
+
+    public String getText() {
+        return mail.getText();
+    }
+
+    public String getHtml() {
+        return mail.getHtml();
+    }
+
+    public String getTemplateUuid() {
+        return mail.getTemplateUuid();
+    }
+
+    public Map<String, Object> getTemplateVariables() {
+        return mail.getTemplateVariables();
+    }
+
+    public static ContentView of(MailtrapMail content) {
+        return new MailContentView(content);
+    }
+
+    private MailContentView(MailtrapMail content) {
+        this.mail = content;
+    }
+}
+

--- a/src/main/java/io/mailtrap/model/mailvalidation/ResolvedMailContentView.java
+++ b/src/main/java/io/mailtrap/model/mailvalidation/ResolvedMailContentView.java
@@ -1,0 +1,39 @@
+package io.mailtrap.model.mailvalidation;
+
+import java.util.Map;
+
+/**
+ * ContentView implementation for a batch item via ResolvedMailView. Exposes the already-resolved (item-first, base-fallback)
+ * values to the shared content rules.
+ */
+public final class ResolvedMailContentView implements ContentView {
+    private final ResolvedMailView mailView;
+
+    public String getSubject() {
+        return mailView.getSubject();
+    }
+
+    public String getText() {
+        return mailView.getText();
+    }
+
+    public String getHtml() {
+        return mailView.getHtml();
+    }
+
+    public String getTemplateUuid() {
+        return mailView.getTemplateUuid();
+    }
+
+    public Map<String, Object> getTemplateVariables() {
+        return mailView.getTemplateVariables();
+    }
+
+    public static ContentView of(ResolvedMailView mailView) {
+        return new ResolvedMailContentView(mailView);
+    }
+
+    private ResolvedMailContentView(ResolvedMailView mailView) {
+        this.mailView = mailView;
+    }
+}

--- a/src/main/java/io/mailtrap/model/mailvalidation/ResolvedMailView.java
+++ b/src/main/java/io/mailtrap/model/mailvalidation/ResolvedMailView.java
@@ -1,0 +1,90 @@
+package io.mailtrap.model.mailvalidation;
+
+import io.mailtrap.model.request.emails.Address;
+import io.mailtrap.model.request.emails.BatchEmailBase;
+import io.mailtrap.model.request.emails.EmailAttachment;
+import io.mailtrap.model.request.emails.MailtrapMail;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Read-only overlay that resolves the effective values (either from `base` or mail item) for batch request validation
+ */
+public final class ResolvedMailView {
+
+    // may be null
+    private final BatchEmailBase base;
+    private final MailtrapMail item;
+
+    public ResolvedMailView(BatchEmailBase base, MailtrapMail item) {
+        this.base = base;
+        this.item = item;
+    }
+
+    @NotNull
+    @Valid
+    public Address getFrom() {
+        Address from = item.getFrom();
+
+        if (from == null && base != null) {
+            from = base.getFrom();
+        }
+
+        return from;
+    }
+
+    public String getSubject() {
+        String subject = item.getSubject();
+
+        if (StringUtils.isBlank(subject) && base != null) {
+            subject = base.getSubject();
+        }
+
+        return subject;
+    }
+
+    public String getText() {
+        String text = item.getText();
+
+        if (StringUtils.isBlank(text) && base != null) {
+            text = base.getText();
+        }
+
+        return text;
+    }
+
+    public String getHtml() {
+        String html = item.getHtml();
+
+        if (StringUtils.isBlank(html) && base != null) {
+            html = base.getHtml();
+        }
+
+        return html;
+    }
+
+    public String getTemplateUuid() {
+        String templateUuid = item.getTemplateUuid();
+
+        if (StringUtils.isBlank(templateUuid) && base != null) {
+            templateUuid = base.getTemplateUuid();
+        }
+
+        return templateUuid;
+    }
+
+    public Map<String, Object> getTemplateVariables() {
+        Map<String, Object> templateVariables = item.getTemplateVariables();
+
+        if ((templateVariables == null || templateVariables.isEmpty()) && base != null) {
+            templateVariables = base.getTemplateVariables();
+        }
+
+        return templateVariables;
+    }
+}

--- a/src/main/java/io/mailtrap/model/request/emails/BatchEmailBase.java
+++ b/src/main/java/io/mailtrap/model/request/emails/BatchEmailBase.java
@@ -1,0 +1,67 @@
+package io.mailtrap.model.request.emails;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+@Builder
+public class BatchEmailBase {
+
+    private Address from;
+
+    @JsonProperty("reply_to")
+    private Address replyTo;
+
+    @Size(min = 1)
+    private String subject;
+
+    /**
+     * Can be used alongside with {@link #html} as a fallback option.
+     * Required in the absence of {@link #html}
+     */
+    private String text;
+
+    /**
+     * Can be used alongside with {@link #text} as a fallback option.
+     * Required in the absence of {@link #text}
+     */
+    private String html;
+
+    @Valid
+    private List<EmailAttachment> attachments;
+
+    /**
+     * 'Content-Transfer-Encoding' header will be ignored and replaced with 'quoted-printable'
+     */
+    private Map<String, String> headers;
+
+    @Size(max = 255)
+    private String category;
+
+    /**
+     * Values that are specific to the entire send that will be carried along with the email and its activity data
+     */
+    @JsonProperty("custom_properties")
+    private Map<String, String> customVariables;
+
+    /**
+     * Should NOT be used if {@link #subject}, {@link #text} or {@link #html} is used
+     */
+    @JsonProperty("template_uuid")
+    private String templateUuid;
+
+    /**
+     * Should be sent if {@link #templateUuid} is used
+     */
+    @JsonProperty("template_variables")
+    private Map<String, Object> templateVariables;
+
+}

--- a/src/main/java/io/mailtrap/model/request/emails/BatchEmailBase.java
+++ b/src/main/java/io/mailtrap/model/request/emails/BatchEmailBase.java
@@ -49,7 +49,7 @@ public class BatchEmailBase {
     /**
      * Values that are specific to the entire send that will be carried along with the email and its activity data
      */
-    @JsonProperty("custom_properties")
+    @JsonProperty("custom_variables")
     private Map<String, String> customVariables;
 
     /**

--- a/src/main/java/io/mailtrap/model/request/emails/MailtrapBatchMail.java
+++ b/src/main/java/io/mailtrap/model/request/emails/MailtrapBatchMail.java
@@ -1,6 +1,9 @@
 package io.mailtrap.model.request.emails;
 
 import io.mailtrap.model.AbstractModel;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,8 +15,12 @@ import java.util.List;
 @Builder
 public class MailtrapBatchMail extends AbstractModel {
 
+    @Valid
     private BatchEmailBase base;
 
+    @NotNull
+    @Size(min = 1)
+    @Valid
     private List<MailtrapMail> requests;
 
 }

--- a/src/main/java/io/mailtrap/model/request/emails/MailtrapBatchMail.java
+++ b/src/main/java/io/mailtrap/model/request/emails/MailtrapBatchMail.java
@@ -1,0 +1,19 @@
+package io.mailtrap.model.request.emails;
+
+import io.mailtrap.model.AbstractModel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class MailtrapBatchMail extends AbstractModel {
+
+    private BatchEmailBase base;
+
+    private List<MailtrapMail> requests;
+
+}

--- a/src/main/java/io/mailtrap/model/response/emails/BatchSendDetails.java
+++ b/src/main/java/io/mailtrap/model/response/emails/BatchSendDetails.java
@@ -1,0 +1,17 @@
+package io.mailtrap.model.response.emails;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class BatchSendDetails {
+
+    private boolean success;
+
+    @JsonProperty("message_ids")
+    private List<String> messageIds;
+
+    private List<String> errors;
+}

--- a/src/main/java/io/mailtrap/model/response/emails/BatchSendResponse.java
+++ b/src/main/java/io/mailtrap/model/response/emails/BatchSendResponse.java
@@ -1,0 +1,16 @@
+package io.mailtrap.model.response.emails;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class BatchSendResponse {
+
+    private boolean success;
+
+    private List<BatchSendDetails> responses;
+
+    private List<String> errors;
+
+}

--- a/src/test/java/io/mailtrap/api/bulkemails/BulkEmailsImplTest.java
+++ b/src/test/java/io/mailtrap/api/bulkemails/BulkEmailsImplTest.java
@@ -77,7 +77,7 @@ class BulkEmailsImplTest extends BaseSendTest {
 
         // Assert
         InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> bulkEmails.send(mail));
-        assertEquals(TEMPLATE_UUID_OR_SUBJECT_AND_TEXT_OR_HTML_MUST_NOT_BE_EMPTY, exception.getMessage());
+        assertEquals(MAIL_MUST_HAVE_SUBJECT_AND_EITHER_TEXT_OR_HTML, exception.getMessage());
     }
 
     @Test

--- a/src/test/java/io/mailtrap/api/bulkemails/BulkEmailsImplTest.java
+++ b/src/test/java/io/mailtrap/api/bulkemails/BulkEmailsImplTest.java
@@ -199,7 +199,7 @@ class BulkEmailsImplTest extends BaseSendTest {
         // Set up test data
         MailtrapBatchMail batchMail = MailtrapBatchMail.builder()
             .base(BatchEmailBase.builder().subject("Sample valid mail subject").text("Sample valid mail text").build())
-            .requests(List.of(createValidTestMailForBatchWithNoSubjectAndText())).build();
+            .requests(List.of(createTestMailForBatchWithNoSubjectAndText())).build();
 
         // Perform call
         BatchSendResponse response = bulkEmails.batchSend(batchMail);
@@ -210,11 +210,11 @@ class BulkEmailsImplTest extends BaseSendTest {
     }
 
     @Test
-    void batchSend_InvalidMailWithNoSubjectAndTextNoBase_SuccessResponse() {
+    void batchSend_InvalidMailWithNoSubjectAndTextNoBase_ThrowsInvalidRequestBodyException() {
         // Set up test data
         MailtrapBatchMail batchMail = MailtrapBatchMail.builder()
             .base(BatchEmailBase.builder().text("Sample valid mail text").build())
-            .requests(List.of(createValidTestMailForBatchWithNoSubjectAndText())).build();
+            .requests(List.of(createTestMailForBatchWithNoSubjectAndText())).build();
 
         // Assert
         InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> bulkEmails.batchSend(batchMail));

--- a/src/test/java/io/mailtrap/api/bulkemails/BulkEmailsImplTest.java
+++ b/src/test/java/io/mailtrap/api/bulkemails/BulkEmailsImplTest.java
@@ -102,6 +102,16 @@ class BulkEmailsImplTest extends BaseSendTest {
     }
 
     @Test
+    void send_MailWithSubjectAndNoTextNoHtml_ThrowsInvalidRequestBodyException() {
+        // Set up invalid data
+        MailtrapMail mail = createTestMailWithSubjectAndNoTextAndNoHtml();
+
+        // Assert
+        InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> bulkEmails.send(mail));
+        assertEquals(MAIL_MUST_HAVE_SUBJECT_AND_EITHER_TEXT_OR_HTML, exception.getMessage());
+    }
+
+    @Test
     void send_NullableMail_ThrowsInvalidRequestBodyException() {
         // Assert
         InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> bulkEmails.send(null));

--- a/src/test/java/io/mailtrap/api/sendingemails/SendingEmailsImplTest.java
+++ b/src/test/java/io/mailtrap/api/sendingemails/SendingEmailsImplTest.java
@@ -77,7 +77,7 @@ class SendingEmailsImplTest extends BaseSendTest {
 
         // Assert
         InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> sendApi.send(mail));
-        assertEquals(TEMPLATE_UUID_OR_SUBJECT_AND_TEXT_OR_HTML_MUST_NOT_BE_EMPTY, exception.getMessage());
+        assertEquals(MAIL_MUST_HAVE_SUBJECT_AND_EITHER_TEXT_OR_HTML, exception.getMessage());
     }
 
     @Test

--- a/src/test/java/io/mailtrap/api/sendingemails/SendingEmailsImplTest.java
+++ b/src/test/java/io/mailtrap/api/sendingemails/SendingEmailsImplTest.java
@@ -199,7 +199,7 @@ class SendingEmailsImplTest extends BaseSendTest {
         // Set up test data
         MailtrapBatchMail batchMail = MailtrapBatchMail.builder()
             .base(BatchEmailBase.builder().subject("Sample valid mail subject").text("Sample valid mail text").build())
-            .requests(List.of(createValidTestMailForBatchWithNoSubjectAndText())).build();
+            .requests(List.of(createTestMailForBatchWithNoSubjectAndText())).build();
 
         // Perform call
         BatchSendResponse response = sendApi.batchSend(batchMail);
@@ -210,11 +210,11 @@ class SendingEmailsImplTest extends BaseSendTest {
     }
 
     @Test
-    void batchSend_InvalidMailWithNoSubjectAndTextNoBase_SuccessResponse() {
+    void batchSend_InvalidMailWithNoSubjectAndTextNoBase_ThrowsInvalidRequestBodyException() {
         // Set up test data
         MailtrapBatchMail batchMail = MailtrapBatchMail.builder()
             .base(BatchEmailBase.builder().text("Sample valid mail text").build())
-            .requests(List.of(createValidTestMailForBatchWithNoSubjectAndText())).build();
+            .requests(List.of(createTestMailForBatchWithNoSubjectAndText())).build();
 
         // Assert
         InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> sendApi.batchSend(batchMail));

--- a/src/test/java/io/mailtrap/api/sendingemails/SendingEmailsImplTest.java
+++ b/src/test/java/io/mailtrap/api/sendingemails/SendingEmailsImplTest.java
@@ -4,6 +4,7 @@ import io.mailtrap.Constants;
 import io.mailtrap.config.MailtrapConfig;
 import io.mailtrap.exception.InvalidRequestBodyException;
 import io.mailtrap.factory.MailtrapClientFactory;
+import io.mailtrap.model.request.emails.BatchEmailBase;
 import io.mailtrap.model.request.emails.MailtrapBatchMail;
 import io.mailtrap.model.request.emails.MailtrapMail;
 import io.mailtrap.model.response.emails.BatchSendResponse;
@@ -36,6 +37,14 @@ class SendingEmailsImplTest extends BaseSendTest {
             DataMock.build(
                 Constants.EMAIL_SENDING_SEND_HOST + "/api/batch",
                 "POST", "api/emails/batchSendRequest.json", "api/emails/batchSendResponse.json"
+            ),
+            DataMock.build(
+                Constants.EMAIL_SENDING_SEND_HOST + "/api/batch",
+                "POST", "api/emails/batchSendWithBaseSubjectRequest.json", "api/emails/batchSendResponse.json"
+            ),
+            DataMock.build(
+                Constants.EMAIL_SENDING_SEND_HOST + "/api/batch",
+                "POST", "api/emails/batchSendWithBaseSubjectAndTextRequest.json", "api/emails/batchSendResponse.json"
             ),
             DataMock.build(
                 Constants.EMAIL_SENDING_SEND_HOST + "/api/batch",
@@ -168,6 +177,48 @@ class SendingEmailsImplTest extends BaseSendTest {
         // Assert
         assertTrue(response.isSuccess());
         assertEquals("22222", response.getResponses().get(0).getMessageIds().get(0));
+    }
+
+    @Test
+    void batchSend_ValidMailWithSubjectFromBase_SuccessResponse() {
+        // Set up test data
+        MailtrapBatchMail batchMail = MailtrapBatchMail.builder()
+            .base(BatchEmailBase.builder().subject("Sample valid mail subject").build())
+            .requests(List.of(createValidTestMailForBatchWithNoSubject())).build();
+
+        // Perform call
+        BatchSendResponse response = sendApi.batchSend(batchMail);
+
+        // Assert
+        assertTrue(response.isSuccess());
+        assertEquals("22222", response.getResponses().get(0).getMessageIds().get(0));
+    }
+
+    @Test
+    void batchSend_ValidMailWithSubjectAndTextFromBase_SuccessResponse() {
+        // Set up test data
+        MailtrapBatchMail batchMail = MailtrapBatchMail.builder()
+            .base(BatchEmailBase.builder().subject("Sample valid mail subject").text("Sample valid mail text").build())
+            .requests(List.of(createValidTestMailForBatchWithNoSubjectAndText())).build();
+
+        // Perform call
+        BatchSendResponse response = sendApi.batchSend(batchMail);
+
+        // Assert
+        assertTrue(response.isSuccess());
+        assertEquals("22222", response.getResponses().get(0).getMessageIds().get(0));
+    }
+
+    @Test
+    void batchSend_InvalidMailWithNoSubjectAndTextNoBase_SuccessResponse() {
+        // Set up test data
+        MailtrapBatchMail batchMail = MailtrapBatchMail.builder()
+            .base(BatchEmailBase.builder().text("Sample valid mail text").build())
+            .requests(List.of(createValidTestMailForBatchWithNoSubjectAndText())).build();
+
+        // Assert
+        InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> sendApi.batchSend(batchMail));
+        assertEquals(SUBJECT_MUST_NOT_BE_NULL, exception.getMessage());
     }
 
     @Test

--- a/src/test/java/io/mailtrap/api/sendingemails/SendingEmailsImplTest.java
+++ b/src/test/java/io/mailtrap/api/sendingemails/SendingEmailsImplTest.java
@@ -102,6 +102,16 @@ class SendingEmailsImplTest extends BaseSendTest {
     }
 
     @Test
+    void send_MailWithSubjectAndNoTextNoHtml_ThrowsInvalidRequestBodyException() {
+        // Set up invalid data
+        MailtrapMail mail = createTestMailWithSubjectAndNoTextAndNoHtml();
+
+        // Assert
+        InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> sendApi.send(mail));
+        assertEquals(MAIL_MUST_HAVE_SUBJECT_AND_EITHER_TEXT_OR_HTML, exception.getMessage());
+    }
+
+    @Test
     void send_NullableMail_ThrowsInvalidRequestBodyException() {
         // Assert
         InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> sendApi.send(null));

--- a/src/test/java/io/mailtrap/api/sendingemails/SendingEmailsImplTest.java
+++ b/src/test/java/io/mailtrap/api/sendingemails/SendingEmailsImplTest.java
@@ -4,7 +4,9 @@ import io.mailtrap.Constants;
 import io.mailtrap.config.MailtrapConfig;
 import io.mailtrap.exception.InvalidRequestBodyException;
 import io.mailtrap.factory.MailtrapClientFactory;
+import io.mailtrap.model.request.emails.MailtrapBatchMail;
 import io.mailtrap.model.request.emails.MailtrapMail;
+import io.mailtrap.model.response.emails.BatchSendResponse;
 import io.mailtrap.model.response.emails.SendResponse;
 import io.mailtrap.testutils.BaseSendTest;
 import io.mailtrap.testutils.DataMock;
@@ -23,20 +25,28 @@ class SendingEmailsImplTest extends BaseSendTest {
     @BeforeEach
     public void init() {
         TestHttpClient httpClient = new TestHttpClient(List.of(
-                DataMock.build(
-                        Constants.EMAIL_SENDING_SEND_HOST + "/api/send",
-                        "POST", "api/emails/sendRequest.json", "api/emails/sendResponse.json"
-                ),
-                DataMock.build(
-                        Constants.EMAIL_SENDING_SEND_HOST + "/api/send",
-                        "POST", "api/emails/sendRequestFromTemplate.json", "api/emails/sendResponse.json"
-                )
+            DataMock.build(
+                Constants.EMAIL_SENDING_SEND_HOST + "/api/send",
+                "POST", "api/emails/sendRequest.json", "api/emails/sendResponse.json"
+            ),
+            DataMock.build(
+                Constants.EMAIL_SENDING_SEND_HOST + "/api/send",
+                "POST", "api/emails/sendRequestFromTemplate.json", "api/emails/sendResponse.json"
+            ),
+            DataMock.build(
+                Constants.EMAIL_SENDING_SEND_HOST + "/api/batch",
+                "POST", "api/emails/batchSendRequest.json", "api/emails/batchSendResponse.json"
+            ),
+            DataMock.build(
+                Constants.EMAIL_SENDING_SEND_HOST + "/api/batch",
+                "POST", "api/emails/batchSendRequestFromTemplate.json", "api/emails/batchSendResponse.json"
+            )
         ));
 
         MailtrapConfig testConfig = new MailtrapConfig.Builder()
-                .httpClient(httpClient)
-                .token("dummy_token")
-                .build();
+            .httpClient(httpClient)
+            .token("dummy_token")
+            .build();
 
         sendApi = MailtrapClientFactory.createMailtrapClient(testConfig).sendingApi().emails();
     }
@@ -122,5 +132,48 @@ class SendingEmailsImplTest extends BaseSendTest {
         // Assert
         assertTrue(response.isSuccess());
         assertEquals("11111", response.getMessageIds().get(0));
+    }
+
+    @Test
+    void batchSend_ValidMail_SuccessResponse() {
+        // Set up test data
+        MailtrapBatchMail batchMail = MailtrapBatchMail.builder().requests(List.of(createValidTestMail())).build();
+
+        // Perform call
+        BatchSendResponse response = sendApi.batchSend(batchMail);
+
+        // Assert
+        assertTrue(response.isSuccess());
+        assertEquals("22222", response.getResponses().get(0).getMessageIds().get(0));
+    }
+
+    @Test
+    void batchSend_ValidMailFromTemplate_SuccessResponse() {
+        // Set up test data
+        MailtrapBatchMail batchMail = MailtrapBatchMail.builder().requests(List.of(createTestMailFromTemplate())).build();
+
+        // Perform call
+        BatchSendResponse response = sendApi.batchSend(batchMail);
+
+        // Assert
+        assertTrue(response.isSuccess());
+        assertEquals("22222", response.getResponses().get(0).getMessageIds().get(0));
+    }
+
+    @Test
+    void batchSend_NullableMail_ThrowsInvalidRequestBodyException() {
+        // Assert
+        InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> sendApi.batchSend(null));
+        assertEquals(BATCH_MAIL_MUST_NOT_BE_NULL, exception.getMessage());
+    }
+
+    @Test
+    void batchSend_MailWithTemplateUuidAndText_ThrowsInvalidRequestBodyException() {
+        // Set up invalid data
+        MailtrapBatchMail batchMail = MailtrapBatchMail.builder().requests(List.of(createTestMailWithTemplateUuidAndText())).build();
+
+        // Assert
+        InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> sendApi.batchSend(batchMail));
+        assertEquals(TEMPLATE_UUID_IS_USED_SUBJECT_AND_TEXT_AND_HTML_SHOULD_BE_EMPTY, exception.getMessage());
     }
 }

--- a/src/test/java/io/mailtrap/api/testingemails/TestingEmailsImplTest.java
+++ b/src/test/java/io/mailtrap/api/testingemails/TestingEmailsImplTest.java
@@ -104,6 +104,16 @@ class TestingEmailsImplTest extends BaseSendTest {
     }
 
     @Test
+    void send_MailWithSubjectAndNoTextNoHtml_ThrowsInvalidRequestBodyException() {
+        // Set up invalid data
+        MailtrapMail mail = createTestMailWithSubjectAndNoTextAndNoHtml();
+
+        // Assert
+        InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> testingApi.send(mail, INBOX_ID));
+        assertEquals(MAIL_MUST_HAVE_SUBJECT_AND_EITHER_TEXT_OR_HTML, exception.getMessage());
+    }
+
+    @Test
     void send_NullableMail_ThrowsInvalidRequestBodyException() {
         // Assert
         InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> testingApi.send(null, INBOX_ID));

--- a/src/test/java/io/mailtrap/api/testingemails/TestingEmailsImplTest.java
+++ b/src/test/java/io/mailtrap/api/testingemails/TestingEmailsImplTest.java
@@ -79,7 +79,7 @@ class TestingEmailsImplTest extends BaseSendTest {
 
         // Assert
         InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> testingApi.send(mail, INBOX_ID));
-        assertEquals(TEMPLATE_UUID_OR_SUBJECT_AND_TEXT_OR_HTML_MUST_NOT_BE_EMPTY, exception.getMessage());
+        assertEquals(MAIL_MUST_HAVE_SUBJECT_AND_EITHER_TEXT_OR_HTML, exception.getMessage());
     }
 
     @Test

--- a/src/test/java/io/mailtrap/api/testingemails/TestingEmailsImplTest.java
+++ b/src/test/java/io/mailtrap/api/testingemails/TestingEmailsImplTest.java
@@ -201,7 +201,7 @@ class TestingEmailsImplTest extends BaseSendTest {
         // Set up test data
         MailtrapBatchMail batchMail = MailtrapBatchMail.builder()
             .base(BatchEmailBase.builder().subject("Sample valid mail subject").text("Sample valid mail text").build())
-            .requests(List.of(createValidTestMailForBatchWithNoSubjectAndText())).build();
+            .requests(List.of(createTestMailForBatchWithNoSubjectAndText())).build();
 
         // Perform call
         BatchSendResponse response = testingApi.batchSend(batchMail, INBOX_ID);
@@ -212,11 +212,11 @@ class TestingEmailsImplTest extends BaseSendTest {
     }
 
     @Test
-    void batchSend_InvalidMailWithNoSubjectAndTextNoBase_SuccessResponse() {
+    void batchSend_InvalidMailWithNoSubjectAndTextNoBase_ThrowsInvalidRequestBodyException() {
         // Set up test data
         MailtrapBatchMail batchMail = MailtrapBatchMail.builder()
             .base(BatchEmailBase.builder().text("Sample valid mail text").build())
-            .requests(List.of(createValidTestMailForBatchWithNoSubjectAndText())).build();
+            .requests(List.of(createTestMailForBatchWithNoSubjectAndText())).build();
 
         // Assert
         InvalidRequestBodyException exception = assertThrows(InvalidRequestBodyException.class, () -> testingApi.batchSend(batchMail, INBOX_ID));

--- a/src/test/java/io/mailtrap/client/MailtrapClientTest.java
+++ b/src/test/java/io/mailtrap/client/MailtrapClientTest.java
@@ -4,7 +4,9 @@ import io.mailtrap.Constants;
 import io.mailtrap.config.MailtrapConfig;
 import io.mailtrap.exception.BaseMailtrapException;
 import io.mailtrap.factory.MailtrapClientFactory;
+import io.mailtrap.model.request.emails.MailtrapBatchMail;
 import io.mailtrap.model.request.emails.MailtrapMail;
+import io.mailtrap.model.response.emails.BatchSendResponse;
 import io.mailtrap.model.response.emails.SendResponse;
 import io.mailtrap.testutils.BaseSendTest;
 import io.mailtrap.testutils.DataMock;
@@ -24,20 +26,29 @@ class MailtrapClientTest extends BaseSendTest {
     @BeforeEach
     void setUp() {
         TestHttpClient httpClient = new TestHttpClient(List.of(
-                DataMock.build(Constants.EMAIL_TESTING_SEND_HOST + "/api/send/" + INBOX_ID, "POST",
-                        "api/emails/sendRequest.json", "api/emails/sendResponse.json"),
+            DataMock.build(Constants.EMAIL_TESTING_SEND_HOST + "/api/send/" + INBOX_ID, "POST",
+                "api/emails/sendRequest.json", "api/emails/sendResponse.json"),
 
-                DataMock.build(Constants.BULK_SENDING_HOST + "/api/send", "POST",
-                        "api/emails/sendRequest.json", "api/emails/sendResponse.json"),
+            DataMock.build(Constants.BULK_SENDING_HOST + "/api/send", "POST",
+                "api/emails/sendRequest.json", "api/emails/sendResponse.json"),
 
-                DataMock.build(Constants.EMAIL_SENDING_SEND_HOST + "/api/send", "POST",
-                        "api/emails/sendRequest.json", "api/emails/sendResponse.json")
+            DataMock.build(Constants.EMAIL_SENDING_SEND_HOST + "/api/send", "POST",
+                "api/emails/sendRequest.json", "api/emails/sendResponse.json"),
+
+            DataMock.build(Constants.EMAIL_TESTING_SEND_HOST + "/api/batch/" + INBOX_ID, "POST",
+                "api/emails/batchSendRequest.json", "api/emails/batchSendResponse.json"),
+
+            DataMock.build(Constants.BULK_SENDING_HOST + "/api/batch", "POST",
+                "api/emails/batchSendRequest.json", "api/emails/batchSendResponse.json"),
+
+            DataMock.build(Constants.EMAIL_SENDING_SEND_HOST + "/api/batch", "POST",
+                "api/emails/batchSendRequest.json", "api/emails/batchSendResponse.json")
         ));
 
         MailtrapConfig mailtrapConfig = new MailtrapConfig.Builder()
-                .token("dummy-token")
-                .httpClient(httpClient)
-                .build();
+            .token("dummy-token")
+            .httpClient(httpClient)
+            .build();
 
         mailtrapClient = MailtrapClientFactory.createMailtrapClient(mailtrapConfig);
     }
@@ -83,12 +94,55 @@ class MailtrapClientTest extends BaseSendTest {
     }
 
     @Test
+    void test_batchSendBulk_success() {
+        // Set up test data
+        MailtrapBatchMail batchMail = MailtrapBatchMail.builder().requests(List.of(createValidTestMail())).build();
+
+        mailtrapClient.switchToBulkSendingApi();
+
+        // Call
+        BatchSendResponse response = mailtrapClient.batchSend(batchMail);
+
+        // Assert
+        assertEquals(1, response.getResponses().size());
+        assertEquals("22222", response.getResponses().get(0).getMessageIds().get(0));
+    }
+
+    @Test
+    void test_batchSendSandbox_success() {
+        // Set up test data
+        MailtrapBatchMail batchMail = MailtrapBatchMail.builder().requests(List.of(createValidTestMail())).build();
+
+        mailtrapClient.switchToEmailTestingApi(INBOX_ID);
+
+        // Call
+        BatchSendResponse response = mailtrapClient.batchSend(batchMail);
+
+        // Assert
+        assertEquals(1, response.getResponses().size());
+        assertEquals("22222", response.getResponses().get(0).getMessageIds().get(0));
+    }
+
+    @Test
+    void test_batchSend_success() {
+        // Set up test data
+        MailtrapBatchMail batchMail = MailtrapBatchMail.builder().requests(List.of(createValidTestMail())).build();
+
+        // Call
+        BatchSendResponse response = mailtrapClient.batchSend(batchMail);
+
+        // Assert
+        assertEquals(1, response.getResponses().size());
+        assertEquals("22222", response.getResponses().get(0).getMessageIds().get(0));
+    }
+
+    @Test
     void test_bulkAndSandboxTrue_ThrowsBaseMailtrapException() {
         // Set up test data and call
         BaseMailtrapException exception = assertThrows(BaseMailtrapException.class, () -> new MailtrapConfig.Builder()
-                .bulk(true)
-                .sandbox(true)
-                .build());
+            .bulk(true)
+            .sandbox(true)
+            .build());
 
         // Assert
         assertEquals(BULK_AND_SANDBOX_TRUE_IN_SENDING_CONFIG, exception.getMessage());
@@ -98,9 +152,9 @@ class MailtrapClientTest extends BaseSendTest {
     void test_sandboxTrueAndInboxIdIsNull_ThrowsBaseMailtrapException() {
         // Set up test data and call
         BaseMailtrapException exception = assertThrows(BaseMailtrapException.class, () -> new MailtrapConfig.Builder()
-                .sandbox(true)
-                .inboxId(null)
-                .build());
+            .sandbox(true)
+            .inboxId(null)
+            .build());
 
         // Assert
         assertEquals(INBOX_ID_REQUIRED, exception.getMessage());

--- a/src/test/java/io/mailtrap/testutils/BaseSendTest.java
+++ b/src/test/java/io/mailtrap/testutils/BaseSendTest.java
@@ -17,6 +17,7 @@ public class BaseSendTest {
     protected final String TEMPLATE_UUID_OR_SUBJECT_AND_TEXT_OR_HTML_MUST_NOT_BE_EMPTY = "Mail must have subject and either text or html when templateUuid is not provided";
     protected final String TEMPLATE_UUID_IS_USED_SUBJECT_AND_TEXT_AND_HTML_SHOULD_BE_EMPTY = "When templateUuid is used, subject, text, and html must not be used";
     protected final String TEMPLATE_VARIABLES_SHOULD_BE_USED_WITH_TEMPLATE_UUID = "Mail templateVariables must only be used with templateUuid";
+    protected final String MAIL_MUST_HAVE_SUBJECT_AND_EITHER_TEXT_OR_HTML = "Mail must have subject and either text or html when templateUuid is not provided";
     protected final String MAIL_MUST_NOT_BE_NULL = "Mail must not be null";
     protected final String BATCH_MAIL_MUST_NOT_BE_NULL = "BatchMail must not be null";
 
@@ -69,6 +70,19 @@ public class BaseSendTest {
 
         return MailtrapMail.builder()
                 .from(from)
+                .to(List.of(to))
+                .attachments(List.of(attachment))
+                .build();
+    }
+
+    protected MailtrapMail createTestMailWithSubjectAndNoTextAndNoHtml() {
+        Address from = getAddress("sender@example.com", "John Doe");
+        Address to = getAddress("receiver@example.com", "Jane Doe");
+        EmailAttachment attachment = getAttachment();
+
+        return MailtrapMail.builder()
+                .from(from)
+                .subject("Sample invalidvalid mail subject")
                 .to(List.of(to))
                 .attachments(List.of(attachment))
                 .build();

--- a/src/test/java/io/mailtrap/testutils/BaseSendTest.java
+++ b/src/test/java/io/mailtrap/testutils/BaseSendTest.java
@@ -14,7 +14,6 @@ public class BaseSendTest {
     protected final String BULK_AND_SANDBOX_TRUE_IN_SENDING_CONFIG = "Bulk mode is not applicable for Testing API";
     protected final String INBOX_ID_REQUIRED = "Testing API requires inbox ID";
     protected final String INVALID_REQUEST_EMPTY_BODY_FROM_EMAIL = "Invalid request body. Violations: from.email=must not be empty";
-    protected final String TEMPLATE_UUID_OR_SUBJECT_AND_TEXT_OR_HTML_MUST_NOT_BE_EMPTY = "Mail must have subject and either text or html when templateUuid is not provided";
     protected final String TEMPLATE_UUID_IS_USED_SUBJECT_AND_TEXT_AND_HTML_SHOULD_BE_EMPTY = "When templateUuid is used, subject, text, and html must not be used";
     protected final String TEMPLATE_VARIABLES_SHOULD_BE_USED_WITH_TEMPLATE_UUID = "Mail templateVariables must only be used with templateUuid";
     protected final String MAIL_MUST_HAVE_SUBJECT_AND_EITHER_TEXT_OR_HTML = "Mail must have subject and either text or html when templateUuid is not provided";

--- a/src/test/java/io/mailtrap/testutils/BaseSendTest.java
+++ b/src/test/java/io/mailtrap/testutils/BaseSendTest.java
@@ -20,6 +20,7 @@ public class BaseSendTest {
     protected final String MAIL_MUST_HAVE_SUBJECT_AND_EITHER_TEXT_OR_HTML = "Mail must have subject and either text or html when templateUuid is not provided";
     protected final String MAIL_MUST_NOT_BE_NULL = "Mail must not be null";
     protected final String BATCH_MAIL_MUST_NOT_BE_NULL = "BatchMail must not be null";
+    protected final String SUBJECT_MUST_NOT_BE_NULL = "Subject must not be null or empty";
 
     private Address getAddress(String email, String name) {
         return new Address(email, name);
@@ -44,6 +45,32 @@ public class BaseSendTest {
                 .subject("Sample valid mail subject")
                 .text("Sample valid mail text")
                 .html("<html><body>Test HTML</body></html>")
+                .attachments(List.of(attachment))
+                .build();
+    }
+
+    protected MailtrapMail createValidTestMailForBatchWithNoSubject() {
+        Address from = getAddress("sender@example.com", "John Doe");
+        Address to = getAddress("receiver@example.com", "Jane Doe");
+        EmailAttachment attachment = getAttachment();
+
+        return MailtrapMail.builder()
+                .from(from)
+                .to(List.of(to))
+                .text("Sample valid mail text")
+                .html("<html><body>Test HTML</body></html>")
+                .attachments(List.of(attachment))
+                .build();
+    }
+
+    protected MailtrapMail createValidTestMailForBatchWithNoSubjectAndText() {
+        Address from = getAddress("sender@example.com", "John Doe");
+        Address to = getAddress("receiver@example.com", "Jane Doe");
+        EmailAttachment attachment = getAttachment();
+
+        return MailtrapMail.builder()
+                .from(from)
+                .to(List.of(to))
                 .attachments(List.of(attachment))
                 .build();
     }

--- a/src/test/java/io/mailtrap/testutils/BaseSendTest.java
+++ b/src/test/java/io/mailtrap/testutils/BaseSendTest.java
@@ -63,7 +63,7 @@ public class BaseSendTest {
                 .build();
     }
 
-    protected MailtrapMail createValidTestMailForBatchWithNoSubjectAndText() {
+    protected MailtrapMail createTestMailForBatchWithNoSubjectAndText() {
         Address from = getAddress("sender@example.com", "John Doe");
         Address to = getAddress("receiver@example.com", "Jane Doe");
         EmailAttachment attachment = getAttachment();

--- a/src/test/java/io/mailtrap/testutils/BaseSendTest.java
+++ b/src/test/java/io/mailtrap/testutils/BaseSendTest.java
@@ -18,6 +18,7 @@ public class BaseSendTest {
     protected final String TEMPLATE_UUID_IS_USED_SUBJECT_AND_TEXT_AND_HTML_SHOULD_BE_EMPTY = "When templateUuid is used, subject, text, and html must not be used";
     protected final String TEMPLATE_VARIABLES_SHOULD_BE_USED_WITH_TEMPLATE_UUID = "Mail templateVariables must only be used with templateUuid";
     protected final String MAIL_MUST_NOT_BE_NULL = "Mail must not be null";
+    protected final String BATCH_MAIL_MUST_NOT_BE_NULL = "BatchMail must not be null";
 
     private Address getAddress(String email, String name) {
         return new Address(email, name);

--- a/src/test/resources/api/emails/batchSendRequest.json
+++ b/src/test/resources/api/emails/batchSendRequest.json
@@ -1,0 +1,26 @@
+{
+  "requests": [
+    {
+      "from": {
+        "name": "John Doe",
+        "email": "sender@example.com"
+      },
+      "to": [
+        {
+          "name": "Jane Doe",
+          "email": "receiver@example.com"
+        }
+      ],
+      "attachments": [
+        {
+          "content": "c2FtcGxlIHRleHQgaW4gdGV4dCBmaWxl",
+          "type": "text/plain",
+          "filename": "attachment.txt"
+        }
+      ],
+      "subject": "Sample valid mail subject",
+      "text": "Sample valid mail text",
+      "html": "<html><body>Test HTML</body></html>"
+    }
+  ]
+}

--- a/src/test/resources/api/emails/batchSendRequestFromTemplate.json
+++ b/src/test/resources/api/emails/batchSendRequestFromTemplate.json
@@ -1,0 +1,25 @@
+{
+  "requests": [
+    {
+      "from": {
+        "email": "sender@example.com"
+      },
+      "to": [
+        {
+          "email": "receiver@example.com"
+        }
+      ],
+      "attachments": [
+        {
+          "content": "c2FtcGxlIHRleHQgaW4gdGV4dCBmaWxl",
+          "type": "text/plain",
+          "filename": "attachment.txt"
+        }
+      ],
+      "template_uuid": "imagine-this-is-uuid",
+      "template_variables": {
+        "user_name": "John Doe"
+      }
+    }
+  ]
+}

--- a/src/test/resources/api/emails/batchSendResponse.json
+++ b/src/test/resources/api/emails/batchSendResponse.json
@@ -1,0 +1,13 @@
+{
+  "success": true,
+  "responses": [
+    {
+      "success": true,
+      "message_ids": [
+        "22222"
+      ],
+      "errors": []
+    }
+  ],
+  "errors": []
+}

--- a/src/test/resources/api/emails/batchSendWithBaseSubjectAndTextRequest.json
+++ b/src/test/resources/api/emails/batchSendWithBaseSubjectAndTextRequest.json
@@ -1,0 +1,27 @@
+{
+  "base": {
+    "subject": "Sample valid mail subject",
+    "text": "Sample valid mail text"
+  },
+  "requests": [
+    {
+      "from": {
+        "name": "John Doe",
+        "email": "sender@example.com"
+      },
+      "to": [
+        {
+          "name": "Jane Doe",
+          "email": "receiver@example.com"
+        }
+      ],
+      "attachments": [
+        {
+          "content": "c2FtcGxlIHRleHQgaW4gdGV4dCBmaWxl",
+          "type": "text/plain",
+          "filename": "attachment.txt"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/api/emails/batchSendWithBaseSubjectRequest.json
+++ b/src/test/resources/api/emails/batchSendWithBaseSubjectRequest.json
@@ -1,0 +1,28 @@
+{
+  "base": {
+    "subject": "Sample valid mail subject"
+  },
+  "requests": [
+    {
+      "from": {
+        "name": "John Doe",
+        "email": "sender@example.com"
+      },
+      "to": [
+        {
+          "name": "Jane Doe",
+          "email": "receiver@example.com"
+        }
+      ],
+      "attachments": [
+        {
+          "content": "c2FtcGxlIHRleHQgaW4gdGV4dCBmaWxl",
+          "type": "text/plain",
+          "filename": "attachment.txt"
+        }
+      ],
+      "text": "Sample valid mail text",
+      "html": "<html><body>Test HTML</body></html>"
+    }
+  ]
+}


### PR DESCRIPTION
## Motivation
Implement the `/batch` endpoint for the Sending/Testing/Bulk Emails API to keep the SDK up-to-date

## Changes

- Added batch method to API interfaces and implementations
- Added batchSend method to MailtrapClient
- Covered with unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch send: submit multiple emails in one request across standard, bulk, and sandbox modes; structured per-item results returned.
  * Shared base data for batches with per-email overrides; new public client method to trigger batch sends; new response/detail models.

* **Bug Fixes / Validation**
  * Stronger content validation and clearer error messages for missing subject/text/html and invalid template combinations.

* **Documentation**
  * New Java examples demonstrating batch sending.

* **Tests**
  * Expanded tests and fixtures covering batch scenarios and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->